### PR TITLE
[PT-1211] UMD and ESM hooks for documentation purpose

### DIFF
--- a/src/hooks/useSmplrJs.js
+++ b/src/hooks/useSmplrJs.js
@@ -3,13 +3,26 @@ import { useEffect, useRef } from 'react'
 import useScript from './useScript'
 import useStylesheet from './useStylesheet'
 
-export default function useSmplrJs ({ onLoad, dev = false }) {
+const SMPLR = {
+  umd: {
+    dev: 'https://dev.smplrspace.com/lib/smplr.js',
+    prod: 'https://app.smplrspace.com/lib/smplr.js'
+  },
+  esm: {
+    dev: 'https://dev.smplrspace.com/lib/smplr.mjs',
+    prod: 'https://app.smplrspace.com/lib/smplr.mjs'
+  },
+  css: {
+    dev: 'https://dev.smplrspace.com/lib/smplr.css',
+    prod: 'https://app.smplrspace.com/lib/smplr.css'
+  }
+}
+
+export function useSmplrJsUMD ({ onLoad, dev = false }) {
   const loaded = useRef(false)
 
-  const smplrjsStatus = useScript(
-    `https://${dev ? 'dev' : 'app'}.smplrspace.com/lib/smplr.js`
-  )
-  useStylesheet(`https://${dev ? 'dev' : 'app'}.smplrspace.com/lib/smplr.css`)
+  const smplrjsStatus = useScript(SMPLR.umd[dev ? 'dev' : 'prod'])
+  useStylesheet(SMPLR.css[dev ? 'dev' : 'prod'])
 
   useEffect(() => {
     if (smplrjsStatus === 'ready' && !loaded.current) {
@@ -18,3 +31,12 @@ export default function useSmplrJs ({ onLoad, dev = false }) {
     }
   }, [onLoad, smplrjsStatus])
 }
+
+export function useSmplrJsESM ({ onLoad, dev = false }) {
+  useStylesheet(SMPLR.css[dev ? 'dev' : 'prod'])
+  useEffect(() => {
+    import(SMPLR.esm[dev ? 'dev' : 'prod']).then(onLoad)
+  }, [onLoad, dev])
+}
+
+export default useSmplrJsUMD

--- a/src/pages/examples/hello-world/HelloWorld.js
+++ b/src/pages/examples/hello-world/HelloWorld.js
@@ -1,25 +1,16 @@
+/* global smplr */
 import React from 'react'
-import { useSmplrJsESM } from '../../../hooks/useSmplrJs'
 
-const ENV = 'dev'
-const CONFIG = {
-  spaceId: {
-    dev: '96eae952-ef60-4058-aba1-6ace322506e7',
-    prod: 'edb2ebaa-47ea-4e54-af0d-cf543328bdb0'
-  },
-  clientToken: {
-    dev: 'pub_x',
-    prod: 'pub_eb760fee77634cdab2fe31146fc371c2'
-  }
-}
+import useSmplrJs from '../../../hooks/useSmplrJs'
 
 const HelloWorld = () => {
-  useSmplrJsESM({ onLoad, dev: ENV === 'dev' })
+  useSmplrJs({ onLoad, dev: false })
 
-  function onLoad (smplr) {
+  function onLoad () {
     const space = new smplr.Space({
-      spaceId: CONFIG.spaceId[ENV],
-      clientToken: CONFIG.clientToken[ENV],
+      spaceId: 'edb2ebaa-47ea-4e54-af0d-cf543328bdb0', // prod
+      // spaceId: '96eae952-ef60-4058-aba1-6ace322506e7', // dev
+      clientToken: 'pub_eb760fee77634cdab2fe31146fc371c2',
       containerId: 'smplr-container'
     })
     space.startViewer({

--- a/src/pages/examples/hello-world/HelloWorld.js
+++ b/src/pages/examples/hello-world/HelloWorld.js
@@ -1,16 +1,25 @@
-/* global smplr */
 import React from 'react'
+import { useSmplrJsESM } from '../../../hooks/useSmplrJs'
 
-import useSmplrJs from '../../../hooks/useSmplrJs'
+const ENV = 'dev'
+const CONFIG = {
+  spaceId: {
+    dev: '96eae952-ef60-4058-aba1-6ace322506e7',
+    prod: 'edb2ebaa-47ea-4e54-af0d-cf543328bdb0'
+  },
+  clientToken: {
+    dev: 'pub_x',
+    prod: 'pub_eb760fee77634cdab2fe31146fc371c2'
+  }
+}
 
 const HelloWorld = () => {
-  useSmplrJs({ onLoad, dev: false })
+  useSmplrJsESM({ onLoad, dev: ENV === 'dev' })
 
-  function onLoad () {
+  function onLoad (smplr) {
     const space = new smplr.Space({
-      spaceId: 'edb2ebaa-47ea-4e54-af0d-cf543328bdb0', // prod
-      // spaceId: '96eae952-ef60-4058-aba1-6ace322506e7', // dev
-      clientToken: 'pub_eb760fee77634cdab2fe31146fc371c2',
+      spaceId: CONFIG.spaceId[ENV],
+      clientToken: CONFIG.clientToken[ENV],
       containerId: 'smplr-container'
     })
     space.startViewer({


### PR DESCRIPTION
Docusaurus doesn't support ESM yet but I suggest we still keep the hooks ready for it. The docs also point to the hooks as a reference implementation to loading smplr.js in a react component, so people who're using React and want the `useSmplrJsESM` hook will have it ready.