### PR TITLE
v2.59.0

### DIFF
--- a/docs/api-reference/queryclient/spaces.md
+++ b/docs/api-reference/queryclient/spaces.md
@@ -57,21 +57,44 @@ To list all the spaces on your organization account, you can call the following 
 
 ```ts
 smplrClient.listSpaces({ 
-  organizationId: string; 
-  tagged?: string[] 
+  organizationId: string
+  tagged?: string[]
+  projects?: string[]
+  unit?: 'sqm' | 'sqft'
+  includeLevelBreakdown?: boolean
 }): Promise<{
   sid: string
   deprecated_id: string
   name: string
   created_at: string
   status: string
+  area: number
+  projects: {
+    project_sid: string
+    name: string
+  }[]
+  levels?: {
+    name: string
+    area: number
+  }[]
 }[]>
 ```
 
 - `organizationId` is the unique identifier of your organization in Smplrspace, something like "fbc5617e-5a27-4138-851e-839446121b2e". Personal accounts are also treated as "personal organization". To get your organization's ID, head to the Developers page from the main menu.
 - `tagged` - _optional_ - an array of tags to filter spaces. Only spaces that have **all** the specified tags will be returned (AND logic).
+- `projects` - _optional_ - an array of project SIDs to filter spaces. Only spaces belonging to at least one of the specified projects will be returned (OR logic). Note that if you are using a project-scoped client token, the filtering is applied automatically and this parameter is not needed.
+- `unit` - _optional_ - the unit for area values in the response. Defaults to `'sqm'`.
+- `includeLevelBreakdown` - _optional_ - set to `true` to include a `levels` array in the response with per-level area data. Defaults to `false`.
 
-You can learn more about `sid` and `deprecated_id` in the dedicated [page on SIDs](/guides/sid).
+Each space in the returned array contains:
+- `sid` - the [Smplrspace ID](/guides/sid) of the space.
+- `deprecated_id` - the legacy UUID identifier. See the [page on SIDs](/guides/sid) for details.
+- `name` - the display name of the space.
+- `created_at` - the ISO 8601 timestamp when the space was created.
+- `status` - one of `'draft'`, `'published'`, or `'archived'`.
+- `area` - the total floor area of the published space, in the unit specified by the `unit` parameter.
+- `projects` - the list of projects the space belongs to. Each entry includes `project_sid` and `name`.
+- `levels` - _present only when `includeLevelBreakdown` is `true`_ - the list of levels in the published space, each with a `name` and `area` (in the specified unit). Ordered from ground level up.
 
 ## getSpace
 

--- a/docs/api-reference/space/custom-ux.md
+++ b/docs/api-reference/space/custom-ux.md
@@ -127,6 +127,7 @@ space.startViewer({
   legendPosition?: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right',
   protectScroll?: boolean
   webGpuOptIn?: boolean
+  disableFacadeMode?: boolean
 }) => void
 ```
 
@@ -147,6 +148,7 @@ space.startViewer({
 - `legendPosition` - _optional_ - lets you choose where the legend (if any is configured in the data layers) is rendered. _Default value: 'top-left'_
 - `protectScroll` - _optional_ - lets you force users to use cmd/ctrl + scroll to zoom on desktop, and two fingers to interact with the viewer on touch screens (leaving one-finger scroll free for the page). This allows you implement cooperative gestures easily in apps where the viewer is part of a scrollable page.
 - `webGpuOptIn` - _optional_ - set this to true to opt into WebGPU rendering. WebGPU offers different performance characteristics compared to WebGL depending on the scene and hardware. The viewer automatically falls back to WebGL when WebGPU is not available in the browser. _Default value: false_
+- `disableFacadeMode` - _optional_ - set this to `false` to enable facade-based performance rendering, which delivers faster initial load times and near-instant level switches by only building the interior of the currently visible level. Set to `true` to disable it. This option will become the default in smplr v3. _Default value: undefined (uses space-level setting)_
 
 ### CSS overrides
 

--- a/docs/api-reference/space/custom-ux.md
+++ b/docs/api-reference/space/custom-ux.md
@@ -148,7 +148,11 @@ space.startViewer({
 - `legendPosition` - _optional_ - lets you choose where the legend (if any is configured in the data layers) is rendered. _Default value: 'top-left'_
 - `protectScroll` - _optional_ - lets you force users to use cmd/ctrl + scroll to zoom on desktop, and two fingers to interact with the viewer on touch screens (leaving one-finger scroll free for the page). This allows you implement cooperative gestures easily in apps where the viewer is part of a scrollable page.
 - `webGpuOptIn` - _optional_ - set this to true to opt into WebGPU rendering. WebGPU offers different performance characteristics compared to WebGL depending on the scene and hardware. The viewer automatically falls back to WebGL when WebGPU is not available in the browser. _Default value: false_
-- `disableFacadeMode` - _optional_ - set this to `false` to enable facade-based performance rendering, which delivers faster initial load times and near-instant level switches by only building the interior of the currently visible level. Set to `true` to disable it. This option will become the default in smplr v3. _Default value: undefined (uses space-level setting)_
+- `disableFacadeMode` - _optional_ - controls facade-based performance rendering, which delivers faster initial load times and near-instant level switches by only building the interior of the currently visible level. Set to `false` to enable it, `true` to disable it. _Default value: undefined (uses space-level setting)_
+
+:::warning Breaking change in smplr v3
+Facade-based performance rendering will be **on by default** in smplr v3. To prepare, pass `disableFacadeMode: false` explicitly to opt in now, or pass `disableFacadeMode: true` to keep the current behavior after the upgrade.
+:::
 
 ### CSS overrides
 

--- a/docs/api-reference/space/space.md
+++ b/docs/api-reference/space/space.md
@@ -44,6 +44,7 @@ space.startViewer({
   mode?: '2d' | '3d'
   allowModeChange?: boolean
   onModeChange?: (mode: '2d' | '3d') => void
+  onPartialRenderReady?: () => void
   onReady?: () => void
   onError?: (errorMessage: string) => void
   onResize?: (containerRect: DOMRect) => void
@@ -59,6 +60,7 @@ space.startViewer({
 - `mode` - _optional_ - lets you choose between 2D and 3D rendering. _Default value: 3d_.
 - `allowModeChange` - _optional_ - set this to true to allow users to switch between 2D and 3D. _Default value: false_.
 - `onModeChange` - _optional_ - is called whenever the user changes the mode. Requires allowModeChange to be set to true.
+- `onPartialRenderReady` - _optional_ - is called once the space shell (walls, floors) and object placeholders are in place — the same moment the loading overlay hides. Objects may still be streaming in after this point. Use this to lift your own loading cover earlier than `onReady`, so the progressive reveal of objects is visible to the user.
 - `onReady` - _optional_ - is called once the viewer's initial render is done. You may alternatively use the promise returned by startViewer, which resolves when the viewer is ready.
 - `onError` - _optional_ - is called if an error occur that crashes the viewer. You may alternatively use the promise returned by startViewer to catch errors.
 - `onResize` - _optional_ - is called whenever the viewer is resized, including after the initial render, when the window is resized, or on mobile when the device is rotated between vertical to horizontal positions. This can be used to reposition custom tooltips (e.g.).


### PR DESCRIPTION
Docs for v2.59.0 release.

## Changes

- **[PT-3498]** Update `listSpaces` docs with `area`, `projects` filter, and `includeLevelBreakdown`
- **[PT-3519]** Document `disableFacadeMode` viewer option + v3 breaking change admonition
- **[PT-3529]** Document `onPartialRenderReady` callback

🤖 Generated with [Claude Code](https://claude.com/claude-code)